### PR TITLE
udate goolge_maps dependency to 7.1.0

### DIFF
--- a/flutter_google_places_sdk/pubspec.yaml
+++ b/flutter_google_places_sdk/pubspec.yaml
@@ -21,10 +21,10 @@ dependencies:
       path: flutter_google_places_sdk_ios
 #    path: ../flutter_google_places_sdk_ios
   flutter_google_places_sdk_web:
-#    git:
-#      url: git@github.com:crispybaconsrl/flutter_google_places.git
-#      path: flutter_google_places_sdk_web
-      path: ../flutter_google_places_sdk_web
+    git:
+      url: git@github.com:crispybaconsrl/flutter_google_places.git
+      path: flutter_google_places_sdk_web
+#      path: ../flutter_google_places_sdk_web
   flutter_google_places_sdk_android:
     git:
       url: git@github.com:crispybaconsrl/flutter_google_places.git

--- a/flutter_google_places_sdk/pubspec.yaml
+++ b/flutter_google_places_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk
 
 environment:
@@ -21,10 +21,10 @@ dependencies:
       path: flutter_google_places_sdk_ios
 #    path: ../flutter_google_places_sdk_ios
   flutter_google_places_sdk_web:
-    git:
-      url: git@github.com:crispybaconsrl/flutter_google_places.git
-      path: flutter_google_places_sdk_web
-#    path: ../flutter_google_places_sdk_web
+#    git:
+#      url: git@github.com:crispybaconsrl/flutter_google_places.git
+#      path: flutter_google_places_sdk_web
+      path: ../flutter_google_places_sdk_web
   flutter_google_places_sdk_android:
     git:
       url: git@github.com:crispybaconsrl/flutter_google_places.git

--- a/flutter_google_places_sdk_web/pubspec.yaml
+++ b/flutter_google_places_sdk_web/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
       path: flutter_google_places_sdk_platform_interface
 #    path: ../flutter_google_places_sdk_platform_interface
   js: ^0.6.7
-  google_maps: ^6.3.0
+  google_maps: ^7.1.0
   collection: ^1.17.2 # Can't upgrade to 1.18 due to flutter sdk version
 
 dev_dependencies:


### PR DESCRIPTION
Update google_maps dependency to 7.1.0 to be able to update google_maps_flutter plugin to the latest version (2.6.1). 